### PR TITLE
Fix member page images not rendering

### DIFF
--- a/_includes/portrait.html
+++ b/_includes/portrait.html
@@ -1,5 +1,6 @@
 {% if include.lookup %}
-  {% assign member = site.members 
+  {% assign all_members = site.coremembers | concat: site.labmembers %}
+  {% assign member = all_members
     | where_exp: "member", "member.slug == include.lookup"
     | first
   %}

--- a/_includes/post-info.html
+++ b/_includes/post-info.html
@@ -6,8 +6,9 @@
       | split: ","
       | array_filter
     %}
+    {% assign all_members = site.coremembers | concat: site.labmembers %}
     {% for author in authors %}
-      {% assign member = site.members
+      {% assign member = all_members
         | where_exp: "member", "member.slug == author"
         | first
       %}


### PR DESCRIPTION
Splitting the member page into Lab and Core broke the portrait look up logic. This PR fixes that so the images can render properly again in individual bio pages.

This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
