### PR TITLE
update checkout action to use newest version with node js 24

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -34,7 +34,7 @@ jobs:
         continue-on-error: true
 
       - name: Checkout branch contents
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.01
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -34,7 +34,7 @@ jobs:
         continue-on-error: true
 
       - name: Checkout branch contents
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.01
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.01
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -34,7 +34,7 @@ jobs:
         continue-on-error: true
 
       - name: Checkout branch contents
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.01
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.01
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -33,7 +33,7 @@ jobs:
         continue-on-error: true
 
       - name: Checkout branch contents
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.01
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Ruby packages
         uses: ruby/setup-ruby@ae195bbe749a7cef685ac729197124a48305c1cb #v1.276.0

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -33,7 +33,7 @@ jobs:
         continue-on-error: true
 
       - name: Checkout branch contents
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Install Ruby packages
         uses: ruby/setup-ruby@ae195bbe749a7cef685ac729197124a48305c1cb #v1.276.0

--- a/.github/workflows/first-time-setup.yaml
+++ b/.github/workflows/first-time-setup.yaml
@@ -24,7 +24,7 @@ jobs:
           branch: "gh-pages"
 
       - name: Checkout Pages branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           ref: gh-pages
 

--- a/.github/workflows/first-time-setup.yaml
+++ b/.github/workflows/first-time-setup.yaml
@@ -24,7 +24,7 @@ jobs:
           branch: "gh-pages"
 
       - name: Checkout Pages branch
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.01
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: gh-pages
 

--- a/.github/workflows/update-citations.yaml
+++ b/.github/workflows/update-citations.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Checkout branch contents
         if: github.event.action != 'closed'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}

--- a/.github/workflows/update-citations.yaml
+++ b/.github/workflows/update-citations.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Checkout branch contents
         if: github.event.action != 'closed'
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.01
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}

--- a/.github/workflows/update-url.yaml
+++ b/.github/workflows/update-url.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b #v5
 
       - name: Checkout branch contents
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.01
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: SSH debug
         if: runner.debug == '1'

--- a/.github/workflows/update-url.yaml
+++ b/.github/workflows/update-url.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b #v5
 
       - name: Checkout branch contents
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: SSH debug
         if: runner.debug == '1'

--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -26,13 +26,13 @@ jobs:
         uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 #v3.23
 
       - name: Checkout base branch contents
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.01
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: main
           path: base
 
       - name: Checkout pr branch contents
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.01
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           path: pr
 
@@ -89,7 +89,7 @@ jobs:
         uses: crazy-max/ghaction-dump-context@158bbf4d6158a44a7e13f76295dc55a69e481a6e #v2
 
       - name: Checkout branch contents
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.01
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install packages
         run: npm install yaml semver

--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -26,13 +26,13 @@ jobs:
         uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 #v3.23
 
       - name: Checkout base branch contents
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           ref: main
           path: base
 
       - name: Checkout pr branch contents
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           path: pr
 
@@ -89,7 +89,7 @@ jobs:
         uses: crazy-max/ghaction-dump-context@158bbf4d6158a44a7e13f76295dc55a69e481a6e #v2
 
       - name: Checkout branch contents
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Install packages
         run: npm install yaml semver


### PR DESCRIPTION
This PR updates some of the steps used in actions to use node js 24. I might not have gotten them all, and we may have to dig through all of the steps the external steps we call use.